### PR TITLE
Fix psycopg2 build failure

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get install -y --no-install-recommends libpq-dev gcc \
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libpq-dev gcc libc6-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description

- **This MR adds to the backend `Dockerfile` the `apt-get` installation of `libc6-dev` to fix the psycopg2 build failure.**
- Before this MR, the backend Docker build was failing because of missing standard C library headers.
- This was because we introduced the  `--no-install-recommends` to make the Docker image smaller, but this caused the build to fail.
- We now keep the `--no-install-recommends` flag and install `libc6-dev` explicitly to fix the build failure.

## How to Test

Running the following should now work:

```bash
docker-compose up --build
```

