### PR TITLE
Pre-download Docling model weights at when building Docker image

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: hadolint-docker
         entry: hadolint/hadolint:v2.8.0 hadolint
-        args: ["--ignore=DL3008", "--ignore=DL3013", "--ignore=DL3018"]
+        args: ["--ignore=DL3008", "--ignore=DL3013", "--ignore=DL3018", "--ignore=DL3059"]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.4.0

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,9 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Pre-download Docling models for faster startup
+RUN docling-tools models download  
+
 COPY . /app
 
 EXPOSE 8000

--- a/backend/app/utils/docling_utils.py
+++ b/backend/app/utils/docling_utils.py
@@ -1,6 +1,7 @@
 """Utilities for parsing and chunking documents using docling library."""
 import io
 from logging import Logger
+from pathlib import Path
 
 from docling.backend.docling_parse_v2_backend import DoclingParseV2DocumentBackend
 from docling.chunking import BaseChunker
@@ -14,7 +15,8 @@ def parse_and_chunk_pdf(
 ) -> list:
     """Parse PDF using docling, chunk it, return chunk objects."""
     logger.info(f"Parsing document {pdf_filename} ...")
-    pipeline_options = PdfPipelineOptions()
+    docling_models_path = Path.home() / ".cache" / "docling" / "models"
+    pipeline_options = PdfPipelineOptions(artifacts_path=docling_models_path)
     pipeline_options.do_ocr = True
     pipeline_options.do_table_structure = True
 


### PR DESCRIPTION
Closes #8 

- **This MR modifies the backend Docker image to pre-download Docling model weights.**
- This allows the first executions of documents ingestion to be significantly faster, although the Docker images is now 10.3 GB instead of 5.8 GB (4.5 GB of cached weights...)
- See also: https://ds4sd.github.io/docling/usage/#model-prefetching-and-offline-usage
- Runtime for ingestion of PDFs is now ~5 seconds per page (assuming no need for OCR)