### PR TITLE
Fix 505 error when no headings are found for a chunk

### DIFF
--- a/backend/app/api/v1/ingest_document.py
+++ b/backend/app/api/v1/ingest_document.py
@@ -71,7 +71,9 @@ async def ingest_document(
             serialized_chunks.append(serialized_chunk)
             async_tasks.append(embed_text(serialized_chunk))
         # 2. Run tasks concurrently
+        logger.info(f"Started embedding {len(async_tasks)} chunks...")
         embeddings = await asyncio.gather(*async_tasks)
+        logger.info(f"Successfully embedded all {len(embeddings)} chunks.")
         # 3. Create and add new rows to the database
         for chunk_obj, serialized_chunk, embedding_vector in zip(
             chunk_objects, serialized_chunks, embeddings
@@ -83,7 +85,7 @@ async def ingest_document(
                 doc_id=doc_id,
                 origin_filename=chunk_obj.meta.origin.filename or file.filename,
                 origin_uri=chunk_obj.meta.origin.uri or "",
-                section_headers=list(chunk_obj.meta.headings),
+                section_headers=list(chunk_obj.meta.headings or []),
                 pages=pages,
                 serialized_chunk=serialized_chunk,
                 embedding=embedding_vector,


### PR DESCRIPTION

- **This MR fixes a `505: Internal Server Error` when document chunks are missing headings.**
- The error was due to the fact that `docling`'s `chunker.serialize(chunk=chunk_obj)` tries to extract both the text content and the section headings of a chunk of document text.
- However, sometimes `docling` cannot find any headings in the chunk, and it returns `None` instead of an empty list.
- We now handle this case by providing an empty list `[]` as the `section_headers` field in the serialized chunk if no headings are found.