### PR TITLE
Modify v1/ingest_document to receive just a PDF file w/o extra filename

### DIFF
--- a/backend/app/api/v1/ingest_document.py
+++ b/backend/app/api/v1/ingest_document.py
@@ -7,7 +7,7 @@ from app.db.session import get_db_session
 from app.utils.ai_utils import embed_text
 from app.utils.docling_utils import parse_and_chunk_pdf
 from docling.chunking import HybridChunker
-from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
 from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,7 +18,6 @@ ingest_document_router = APIRouter()
 
 @ingest_document_router.post("/v1/ingest_document")
 async def ingest_document(
-    doc_id: str = Form(...),  # noqa: B008
     file: UploadFile = File(...),  # noqa: B008
     db: AsyncSession = Depends(get_db_session),  # noqa: B008
 ):
@@ -31,9 +30,9 @@ async def ingest_document(
     4) Replace existing doc_id data or inserts new
     5) Return success
     """
-    logger.info(f"Ingesting document with doc_id: {doc_id} and filename: {file.filename}")
-    # Read the PDF bytes
     pdf_bytes = await file.read()
+    doc_id = file.filename
+    logger.info(f"Ingesting document with doc_id: {doc_id} and filename: {file.filename}")
     if not pdf_bytes:
         raise HTTPException(status_code=400, detail="Uploaded file is empty or invalid.")
     await file.close()

--- a/backend/app/api/v1/query.py
+++ b/backend/app/api/v1/query.py
@@ -99,7 +99,7 @@ async def query_documents(
     contexts = []
     for chunk in top_contexts:
         snippet = (
-            f"DocID: {chunk.doc_id}, ChunkID: {chunk.chunk_id}, "
+            f"Doc Name: {chunk.doc_name}, ChunkID: {chunk.chunk_id}, "
             f"Headers: {chunk.section_headers}, Pages: {chunk.pages}\n"
             f"{chunk.serialized_chunk}"
         )

--- a/backend/app/db/models.py
+++ b/backend/app/db/models.py
@@ -12,17 +12,8 @@ class Chunk(Base):
     __tablename__ = "chunks"
 
     chunk_id = Column(Integer, primary_key=True, index=True)
-    doc_id = Column(Text, nullable=False, index=True)
-
-    origin_filename = Column(Text, nullable=True)
-    origin_uri = Column(Text, nullable=True)
-
-    # For arrays, we'll store them as Postgres arrays
+    doc_name = Column(Text, nullable=False, index=True)
     section_headers = Column(postgresql.ARRAY(Text), nullable=True)
     pages = Column(postgresql.ARRAY(Integer), nullable=True)
-
     serialized_chunk = Column(Text, nullable=True)
-
-    # Vector column using pgvector
-    # dimension must match the embedding dimension
     embedding = Column(Vector(app_config.EMBEDDING_DIM))

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -40,10 +40,9 @@ def main():
                     files = {"file": (file_obj.name, file_obj.getvalue(), "application/pdf")}
                     response = requests.post(ingest_url, files=files)
                     response.raise_for_status()
+                    st.success(f"Successfully uploaded {len(uploaded_files)} files to database ✅")
             except requests.exceptions.RequestException as e:
                 st.error(f"Error ingesting {file_obj.name}: {e}")
-
-        st.success(f"Successfully uploaded {len(uploaded_files)} files to database ✅")
 
         # Update session_state
         st.session_state.uploaded_file_names = current_file_names

--- a/frontend/app.py
+++ b/frontend/app.py
@@ -1,6 +1,4 @@
 """Streamlit frontend for AskTheDocs app."""
-from pathlib import Path
-
 import requests
 import streamlit as st
 
@@ -39,9 +37,8 @@ def main():
                 for file_obj in uploaded_files:
                     # Note: file_obj is a Streamlit UploadedFile, not a local path
                     # but we can still pass its `read()` content to requests.
-                    files = {"file": file_obj.getvalue()}
-                    data = {"doc_id": Path(file_obj.name).name}
-                    response = requests.post(ingest_url, data=data, files=files)
+                    files = {"file": (file_obj.name, file_obj.getvalue(), "application/pdf")}
+                    response = requests.post(ingest_url, files=files)
                     response.raise_for_status()
             except requests.exceptions.RequestException as e:
                 st.error(f"Error ingesting {file_obj.name}: {e}")


### PR DESCRIPTION
- **This MR removes `doc_id`. Only the PDF filename is now used.**
- `doc_id` was an extra field required to let the backend know about the name of the uploaded file.
- We now handle everything in a simpler way, and just let the backed know the PDF file name from the uploading itself.